### PR TITLE
MIGSOFTWAR-11409 Disable Key Validation feature on 202305 branch for Cisco Platforms

### DIFF
--- a/sonic_installer/bootloader/grub.py
+++ b/sonic_installer/bootloader/grub.py
@@ -173,9 +173,12 @@ class GrubBootloader(OnieInstallerBootloader):
         fi
         exit 0
         '''
+        asic_type = subprocess.run(['sonic-cfggen', '-y', '/etc/sonic/sonic_version.yml', '-v', 'asic_type'], capture_output=True);
+        if("cisco-8000" in asic_type.stdout.decode()):
+            return 0
         verification_result = subprocess.run(['bash', '-c', check_if_verification_is_enabled_and_supported_code], capture_output=True)
         click.echo(verification_result.stdout.decode())
-        return verification_result.returncode == 0
+        return verification_result.returncode == 0 
 
     def verify_image_sign(self, image_path):
         click.echo('Verifying image signature')

--- a/sonic_installer/bootloader/grub.py
+++ b/sonic_installer/bootloader/grub.py
@@ -173,7 +173,7 @@ class GrubBootloader(OnieInstallerBootloader):
         fi
         exit 0
         '''
-        asic_type = subprocess.run(['sonic-cfggen', '-y', '/etc/sonic/sonic_version.yml', '-v', 'asic_type'], capture_output=True);
+        asic_type = subprocess.run(['sonic-cfggen', '-y', '/etc/sonic/sonic_version.yml', '-v', 'asic_type'], capture_output=True)
         if("cisco-8000" in asic_type.stdout.decode()):
             return 0
         verification_result = subprocess.run(['bash', '-c', check_if_verification_is_enabled_and_supported_code], capture_output=True)

--- a/sonic_installer/bootloader/grub.py
+++ b/sonic_installer/bootloader/grub.py
@@ -178,7 +178,7 @@ class GrubBootloader(OnieInstallerBootloader):
             return 0
         verification_result = subprocess.run(['bash', '-c', check_if_verification_is_enabled_and_supported_code], capture_output=True)
         click.echo(verification_result.stdout.decode())
-        return verification_result.returncode == 0 
+        return verification_result.returncode == 0
 
     def verify_image_sign(self, image_path):
         click.echo('Verifying image signature')


### PR DESCRIPTION
Disabling key validation feature in grub file as its not yet supported for Cisco platforms in 202305 branch

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

1. Check if the platform we are installing the image on is a cisco platform
2. Return success if it is so we are on cisco platform. This way, we do not perform signature verification as this feature is not yet supported on our platforms for 202305 branch

#### How I did it
Modified sonic-installer grub.py code

#### How to verify it
Use sonic-installer command without this fix and try to downgrade from 202305 image to 202205 image, you will see error. With this fix, the image will be installed

#### Previous command output (if the output of a command-line utility has changed)
```
root@yy39-rp:/home/cisco# sonic-installer install sonic-cisco-8000.bin
New image will be installed, continue? [y/N]: y

Verifing image SONiC-OS-azure_cisco_202205.0-dirty-20231023.141040 signature...
Verifying image signature
Failure: CMS signature Verification Failed:

Error: Failed verify image signature
Aborted!
root@yy39-rp:/home/cisco#
```
#### New command output (if the output of a command-line utility has changed)
```
root@yy39-rp:/home/cisco# sonic-installer install sonic-cisco-8000.bin
New image will be installed, continue? [y/N]: y
Installing image SONiC-OS-azure_cisco_202205.0-dirty-20231023.141040 and setting it as default...
Command: bash ./sonic-cisco-8000.bin
Verifying image checksum ... OK.
Preparing image archive ... OK.
Installing SONiC in SONiC
ONIE Installer: platform: x86_64-cisco-8000-r0
onie_platform: x86_64-8800_rp-r0
Installing SONiC to /host/image-azure_cisco_202205.0-dirty-20231023.141040
Archive:  fs.zip
   creating: /host/image-azure_cisco_202205.0-dirty-20231023.141040/boot/
  inflating: /host/image-azure_cisco_202205.0-dirty-20231023.141040/boot/System.map-5.10.0-18-2-amd64
  inflating: /host/image-azure_cisco_202205.0-dirty-20231023.141040/boot/config-5.10.0-18-2-amd64
  inflating: /host/image-azure_cisco_202205.0-dirty-20231023.141040/boot/initrd.img-5.10.0-18-2-amd64
  inflating: /host/image-azure_cisco_202205.0-dirty-20231023.141040/boot/vmlinuz-5.10.0-18-2-amd64
 extracting: /host/image-azure_cisco_202205.0-dirty-20231023.141040/fs.squashfs
Switch CPU vendor is: GenuineIntel
Switch CPU cstates are: disabled
EXTRA_CMDLINE_LINUX=
Installed SONiC base image SONiC-OS successfully

Command: grub-set-default --boot-directory=/host 0

Command: config-setup backup
Taking backup of current configuration

Command: mkdir -p /tmp/image-azure_cisco_202205.0-dirty-20231023.141040-fs
Command: mount -t squashfs /host/image-azure_cisco_202205.0-dirty-20231023.141040/fs.squashfs /tmp/image-azure_cisco_202205.0-dirty-20231023.141040-fs
Command: sonic-cfggen -d -y /tmp/image-azure_cisco_202205.0-dirty-20231023.141040-fs/etc/sonic/sonic_version.yml -t /tmp/image-azure_cisco_202205.0-dirty-20231023.141040-fs/usr/share/sonic/templates/sonic-environment.j2
Command: umount -r -f /tmp/image-azure_cisco_202205.0-dirty-20231023.141040-fs
Command: rm -rf /tmp/image-azure_cisco_202205.0-dirty-20231023.141040-fs
Command: mkdir -p /tmp/image-azure_cisco_202205.0-dirty-20231023.141040-fs
Command: mount -t squashfs /host/image-azure_cisco_202205.0-dirty-20231023.141040/fs.squashfs /tmp/image-azure_cisco_202205.0-dirty-20231023.141040-fs
Command: mkdir -p /host/image-azure_cisco_202205.0-dirty-20231023.141040/rw
Command: mkdir -p /host/image-azure_cisco_202205.0-dirty-20231023.141040/work
Command: mkdir -p /tmp/image-azure_cisco_202205.0-dirty-20231023.141040-fs
Command: mount overlay -t overlay -o rw,relatime,lowerdir=/tmp/image-azure_cisco_202205.0-dirty-20231023.141040-fs,upperdir=/host/image-azure_cisco_202205.0-dirty-20231023.141040/rw,workdir=/host/image-azure_cisco_202205.0-dirty-20231023.141040/work /tmp/image-azure_cisco_202205.0-dirty-20231023.141040-fs
Command: mkdir -p /tmp/image-azure_cisco_202205.0-dirty-20231023.141040-fs/var/lib/docker
Command: mount --bind /host/image-azure_cisco_202205.0-dirty-20231023.141040/docker /tmp/image-azure_cisco_202205.0-dirty-20231023.141040-fs/var/lib/docker
Command: chroot /tmp/image-azure_cisco_202205.0-dirty-20231023.141040-fs mount proc /proc -t proc
Command: chroot /tmp/image-azure_cisco_202205.0-dirty-20231023.141040-fs mount sysfs /sys -t sysfs
Command: cp /tmp/image-azure_cisco_202205.0-dirty-20231023.141040-fs/etc/default/docker /tmp/image-azure_cisco_202205.0-dirty-20231023.141040-fs/tmp/docker_config_backup
Command: sh -c echo 'DOCKER_OPTS="$DOCKER_OPTS -H unix:// --storage-driver=overlay2 --bip=240.127.1.1/24 --iptables=false --ipv6=true --fixed-cidr-v6=fd00::/80 "' >> /tmp/image-azure_cisco_202205.0-dirty-20231023.141040-fs/etc/default/docker
Command: chroot /tmp/image-azure_cisco_202205.0-dirty-20231023.141040-fs /usr/lib/docker/docker.sh start
mount: /sys/fs/cgroup/cpu: cgroup already mounted on /sys/fs/cgroup.
mount: /sys/fs/cgroup/cpuacct: cgroup already mounted on /sys/fs/cgroup.
Command: cp /var/lib/sonic-package-manager/packages.json /tmp/image-azure_cisco_202205.0-dirty-20231023.141040-fs/tmp/packages.json
Command: touch /tmp/image-azure_cisco_202205.0-dirty-20231023.141040-fs/tmp/docker.sock
Command: mount --bind /var/run/docker.sock /tmp/image-azure_cisco_202205.0-dirty-20231023.141040-fs/tmp/docker.sock
Command: cp /tmp/image-azure_cisco_202205.0-dirty-20231023.141040-fs/etc/resolv.conf /tmp/resolv.conf.backup
Command: cp /etc/resolv.conf /tmp/image-azure_cisco_202205.0-dirty-20231023.141040-fs/etc/resolv.conf
Command: chroot /tmp/image-azure_cisco_202205.0-dirty-20231023.141040-fs sh -c command -v sonic-package-manager
Command: chroot /tmp/image-azure_cisco_202205.0-dirty-20231023.141040-fs sonic-package-manager migrate /tmp/packages.json --dockerd-socket /tmp/docker.sock -y
libyang[1]: Unable to get information about "initrd.img" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "initrd.img.old" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz" file in "/" when searching for (sub)modules (No such file or directory)
libyang[1]: Unable to get information about "vmlinuz.old" file in "/" when searching for (sub)modules (No such file or directory)
migrating package dhcp-relay
skipping dhcp-relay as installed version is newer
migrating package macsec
skipping macsec as installed version is newer
Command: chroot /tmp/image-azure_cisco_202205.0-dirty-20231023.141040-fs /usr/lib/docker/docker.sh stop
Command: mv /tmp/image-azure_cisco_202205.0-dirty-20231023.141040-fs/tmp/docker_config_backup /tmp/image-azure_cisco_202205.0-dirty-20231023.141040-fs/etc/default/docker
Command: cp /tmp/resolv.conf.backup /tmp/image-azure_cisco_202205.0-dirty-20231023.141040-fs/etc/resolv.conf
Command: umount -f -R /tmp/image-azure_cisco_202205.0-dirty-20231023.141040-fs
Command: umount -r -f /tmp/image-azure_cisco_202205.0-dirty-20231023.141040-fs
Command: rm -rf /tmp/image-azure_cisco_202205.0-dirty-20231023.141040-fs
Command: sync

Command: sync

Command: sync

Command: sleep 3

Done
root@yy39-rp:/home/cisco#
```